### PR TITLE
Fix attributes for Letter object

### DIFF
--- a/Lob/Models/Request/NewLetter.cs
+++ b/Lob/Models/Request/NewLetter.cs
@@ -8,7 +8,7 @@ namespace Lob
             object to,
             object from,
             string file,
-            int perforatedPage,
+            int? perforatedPage = null,
             string description = null,
             bool color = true,
             object mergeVariables = null,
@@ -17,8 +17,8 @@ namespace Lob
             bool returnEnvelope = false,
             string mailType = "usps_first_class",
             string extraService = null,
-            Nullable <DateTime> sendDate = null,
-            object metaData = null
+            DateTime? sendDate = null,
+            object metadata = null
             )
         {
             Description = description;
@@ -34,10 +34,8 @@ namespace Lob
             MailType = mailType;
             ExtraService = extraService;
             SendDate = sendDate;
-            MetaData = metaData;
+            Metadata = metadata;
         }
-
-        public string Id { get; set; }
 
         public string Description { get; set; }
 
@@ -57,14 +55,14 @@ namespace Lob
 
         public bool ReturnEnvelope { get; set; }
 
-        public int PerforatedPage { get; set; }
+        public int? PerforatedPage { get; set; }
 
         public string MailType { get; set; }
 
         public string ExtraService { get; set; }
 
-        public Nullable <DateTime> SendDate { get; set; }
+        public DateTime? SendDate { get; set; }
 
-        public object MetaData { get; set; }
+        public object Metadata { get; set; }
     }
 }

--- a/Lob/Models/Response/Letter.cs
+++ b/Lob/Models/Response/Letter.cs
@@ -17,11 +17,11 @@ namespace Lob
             bool doubleSided,
             string addressPlacement,
             bool returnEnvelope,
-            int perforatedPage,
+            int? perforatedPage,
             string mailType,
             string extraService,
             DateTime sendDate,
-            object metaData) {
+            object metadata) {
             Id = id;
             Description = description;
             To = to;
@@ -36,7 +36,7 @@ namespace Lob
             MailType = mailType;
             ExtraService = extraService;
             SendDate = sendDate;
-            MetaData = metaData;
+            Metadata = metadata;
         }
 
         public string Id { get; protected set; }
@@ -59,7 +59,7 @@ namespace Lob
 
         public bool ReturnEnvelope { get; protected set; }
 
-        public int PerforatedPage { get; protected set; }
+        public int? PerforatedPage { get; protected set; }
 
         public string MailType { get; protected set; }
 
@@ -67,6 +67,6 @@ namespace Lob
 
         public DateTime SendDate { get; protected set; }
 
-        public object MetaData { get; protected set; }
+        public object Metadata { get; protected set; }
     }
 }


### PR DESCRIPTION
This was preventing a request being sent without perforated page number specified, and for new letter creation it was causing a 422 because "id" and "meta_data" [sic] keys are not allowed.

Make perforated_page optional.
Fix casing on Metadata so default serializer just works.
Removed unused ID parameter from NewLetter model.