### PR TITLE
Fix Request Connection Issues

### DIFF
--- a/Lob/Authentication/BasicAuthenticator.cs
+++ b/Lob/Authentication/BasicAuthenticator.cs
@@ -13,7 +13,7 @@ namespace Lob.Internal
                 CultureInfo.InvariantCulture,
                 "Basic {0}",
                 Convert.ToBase64String(Encoding.UTF8.GetBytes(
-                    string.Format(CultureInfo.InvariantCulture, "{0}:{1}", credentials.ApiKey, null))));
+                    string.Format(CultureInfo.InvariantCulture, "{0}:", credentials.ApiKey))));
 
             request.Headers["Authorization"] = header;
         }

--- a/Lob/Authentication/BasicAuthenticator.cs
+++ b/Lob/Authentication/BasicAuthenticator.cs
@@ -13,7 +13,7 @@ namespace Lob.Internal
                 CultureInfo.InvariantCulture,
                 "Basic {0}",
                 Convert.ToBase64String(Encoding.UTF8.GetBytes(
-                    string.Format(CultureInfo.InvariantCulture, "{0}:{1}", credentials.ApiKey))));
+                    string.Format(CultureInfo.InvariantCulture, "{0}:{1}", credentials.ApiKey, null))));
 
             request.Headers["Authorization"] = header;
         }

--- a/Lob/Http/ApiConnection.cs
+++ b/Lob/Http/ApiConnection.cs
@@ -12,7 +12,7 @@ namespace Lob
     {
         public ApiConnection(IConnection connection)
         {
-
+            Connection = connection;
         }
 
         public IConnection Connection { get; set; }

--- a/Lob/Http/Connection.cs
+++ b/Lob/Http/Connection.cs
@@ -64,6 +64,8 @@ namespace Lob
         Task<IApiResponse<T>> SendDataInternal<T>(object body, string accepts, string contentType, Request request)
         {
             request.Body = body;
+            request.BaseAddress = BaseAddress;
+            request.ContentType = contentType;
             return Run<T>(request);
         }
 
@@ -123,7 +125,7 @@ namespace Lob
 
         static string FormatUserAgent(ProductHeaderValue productInformation)
         {
-            return string.Format(CultureInfo.InvariantCulture, "Lob/v1 C# .NET/", productInformation);
+            return string.Format(CultureInfo.InvariantCulture, "Lob/v1 C# .NET/4.6", productInformation);
         }
     }
 }

--- a/Lob/Http/Connection.cs
+++ b/Lob/Http/Connection.cs
@@ -125,7 +125,7 @@ namespace Lob
 
         static string FormatUserAgent(ProductHeaderValue productInformation)
         {
-            return string.Format(CultureInfo.InvariantCulture, "Lob/v1 C# .NET/4.6", productInformation);
+            return string.Format(CultureInfo.InvariantCulture, "Lob/v1 C# .NET/4.6");
         }
     }
 }

--- a/Lob/Http/HttpClientAdapter.cs
+++ b/Lob/Http/HttpClientAdapter.cs
@@ -104,44 +104,7 @@ namespace Lob.Internal
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
-            var clonedRequest = await CloneHttpRequestMessageAsync(request).ConfigureAwait(false);
-
-            return await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead).ConfigureAwait(false);
-        }
-
-        public static async Task<HttpRequestMessage> CloneHttpRequestMessageAsync(HttpRequestMessage oldRequest)
-        {
-            var newRequest = new HttpRequestMessage(oldRequest.Method, oldRequest.RequestUri);
-
-            var ms = new MemoryStream();
-            if (oldRequest.Content != null)
-            {
-                await oldRequest.Content.CopyToAsync(ms).ConfigureAwait(false);
-                ms.Position = 0;
-                newRequest.Content = new StreamContent(ms);
-
-                if (oldRequest.Content.Headers != null)
-                {
-                    foreach (var h in oldRequest.Headers)
-                    {
-                        newRequest.Content.Headers.Add(h.Key, h.Value);
-                    }
-                }
-            }
-
-            newRequest.Version = oldRequest.Version;
-
-            foreach (var header in oldRequest.Headers)
-            {
-                newRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
-            }
-
-            foreach (var property in oldRequest.Properties)
-            {
-                newRequest.Properties.Add(property);
-            }
-
-            return newRequest;
+           return await _http.SendAsync(request, HttpCompletionOption.ResponseContentRead).ConfigureAwait(false);
         }
 
         internal class RedirectHandler : DelegatingHandler

--- a/Lob/Lob.csproj
+++ b/Lob/Lob.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="xunit" Version="2.3.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" />


### PR DESCRIPTION
Fixed a couple of issues with the API connection classes:
- Basic auth string formatter required a second argument
- Connection object was not being assigned on new ApiConnections
- The base address of a url and the content-type were not being sent
- User-agent string was not a valid format because missing .NET version
- Removed unused(?) clone method that was causing an error
- Manage System.Net.Http through NuGet because I was running into a bug with an older version: https://github.com/dotnet/corefx/issues/9846