### PR TITLE
Add error handling for non successful API requests

### DIFF
--- a/Lob/Http/LobException.cs
+++ b/Lob/Http/LobException.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Net;
+using Lob.Models.Response;
+
+namespace Lob.Http
+{
+    public class LobException : Exception
+    {
+        public HttpStatusCode HttpStatusCode { get; }
+        public LobError LobError { get; set; }
+        public IApiResponse<LobError> ApiResponse { get; set; }
+
+        public LobException(IApiResponse<LobError> response) : base(response.Body.Message)
+        {
+            ApiResponse = response;
+            LobError = response.Body;
+            HttpStatusCode = response.HttpResponse.StatusCode;
+        }
+    }
+}

--- a/Lob/Models/Response/LobError.cs
+++ b/Lob/Models/Response/LobError.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Lob.Models.Response
+{
+    [JsonObject(NamingStrategyType = typeof(SnakeCaseNamingStrategy))]
+    public class LobError
+    {
+        public string StatusCode { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/Test/LettersTests.cs
+++ b/Test/LettersTests.cs
@@ -1,4 +1,7 @@
-﻿using Lob;
+﻿using System.Net;
+using System.Threading.Tasks;
+using Lob;
+using Lob.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LobTests
@@ -6,12 +9,12 @@ namespace LobTests
     [TestClass]
     public class LettersTests
     {
+        private static readonly Credentials TestCredentials = new Credentials("test_fd34e1b5ea86a597ec89f7f2e46940c874d");
+        private static readonly LobClient LobClient = new LobClient("test-app", new CredentialStore(TestCredentials));
+
         [TestMethod]
         public void TestCreate()
         {
-            Credentials testCredentials = new Credentials("test_fd34e1b5ea86a597ec89f7f2e46940c874d");
-            var lobClient = new LobClient("test-app", new CredentialStore(testCredentials));
-
             object fromAddress = new {
                 name = "Test Sender",
                 address_line1 = "185 Berry st",
@@ -37,7 +40,42 @@ namespace LobTests
                 file: "url"
             );
 
-            lobClient.Letter.Create(letter);
+            LobClient.Letter.Create(letter);
+        }
+
+        [TestMethod]
+        public async Task TestEmptyToAddress()
+        {
+            object fromAddress = new
+            {
+                name = "Test Sender",
+                address_line1 = "185 Berry st",
+                address_city = "San Francisco",
+                address_state = "CA",
+                address_zip = "94107",
+                address_country = "US"
+            };
+
+            object toAddress = new
+            {
+                name = "Test Recipient",
+                address_line1 = "",
+                address_city = "San Francisco",
+                address_state = "CA",
+                address_zip = "94107",
+                address_country = "US"
+            };
+
+            NewLetter letter = new NewLetter(
+                description: "test letter",
+                to: toAddress,
+                from: fromAddress,
+                file: "<!doctype html><meta charset=utf-8><body>Test</body></html>"
+            );
+
+            var exception = await Assert.ThrowsExceptionAsync<LobException>(() => LobClient.Letter.Create(letter));
+            Assert.AreEqual(exception.HttpStatusCode, (HttpStatusCode) 422);
+            StringAssert.Contains(exception.Message, "to.address_line1 is required");
         }
     }
 }

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -47,6 +47,9 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.0.1\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -3,6 +3,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.0.0" targetFramework="net461" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
In the event of an error status code from the API, throw an
exception with the error details, instead of trying to parse
default object.

- Add custom LobException class to contain ApiResponse with status
code and error object properties
- Add LobError response object to deserialize error JSON into object
- Add simple test case for handling error response when Letter to
address is empty
- Add Netwonsoft.Json package to Test project to fix conflicting
package error with Lob library