### PR TITLE
feat(address): add address client

### DIFF
--- a/Lob.sln
+++ b/Lob.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2000
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lob", "Lob\Lob.csproj", "{290F7BA4-AEEB-4054-9681-5D052DB13A56}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LobTest", "LobTest\LobTest.csproj", "{B95B591D-B9C2-4CD5-943F-05F32374F33B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{290F7BA4-AEEB-4054-9681-5D052DB13A56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{290F7BA4-AEEB-4054-9681-5D052DB13A56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{290F7BA4-AEEB-4054-9681-5D052DB13A56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{290F7BA4-AEEB-4054-9681-5D052DB13A56}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B95B591D-B9C2-4CD5-943F-05F32374F33B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B95B591D-B9C2-4CD5-943F-05F32374F33B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B95B591D-B9C2-4CD5-943F-05F32374F33B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B95B591D-B9C2-4CD5-943F-05F32374F33B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {30FD9581-FEA1-4E8C-AA83-7B5124EF6592}
+	EndGlobalSection
+EndGlobal

--- a/Lob/Api/Address/AddressClient.cs
+++ b/Lob/Api/Address/AddressClient.cs
@@ -1,0 +1,88 @@
+﻿using Lob.Api.Common;
+using Lob.Common;
+using Lob.Common.Utils;
+using Lob.Protocol;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Lob.Api.Address
+{
+    public class AddressClient
+    {
+        public AddressClient(LobRestClient client)
+        {
+            Client = client;
+        }
+
+        private LobRestClient Client { get; set; }
+
+        public Task<LobResponse<DeletableResource>> DeleteAsync(string id)
+        {
+            return Client.ExecuteAsync<DeletableResource>(
+                HttpMethod.Delete,
+                $"{Constants.AddressResourceEndpoint}/{id}"
+                );
+        }
+
+        public Task<LobResponse<AddressResource>> GetAsync(string id)
+        {
+            Console.WriteLine($"getasync {id}");
+            return Client.ExecuteAsync<AddressResource>(
+                HttpMethod.Get,
+                $"{Constants.AddressResourceEndpoint}/{id}"
+                );
+        }
+
+        // TODO: ListOptions
+        public Task<LobResponse<LobCollection<AddressResource>>> ListAsync()
+        {
+            return Client.ExecuteAsync<LobCollection<AddressResource>>(
+                HttpMethod.Get,
+                Constants.AddressResourceEndpoint
+                );
+        }
+
+        public Task<LobResponse<AddressResource>> CreateAsync(
+                string addressLine1,
+                string addressLine2 = null,
+                string addressCity = null,
+                string addressState = null,
+                string addressZip = null,
+                string addressCountry = null,
+                string description = null,
+                string name = null,
+                string company = null,
+                string phone = null,
+                string email = null,
+                IDictionary<string, string> metadata = null)
+        {
+            return CreateAsync(
+                new CreateAddressRequest()
+                {
+                    Description = description,
+                    Name = name,
+                    Company = company,
+                    AddressLine1 = addressLine1,
+                    AddressLine2 = addressLine2,
+                    AddressCity = addressCity,
+                    AddressState = addressState,
+                    AddressZip = addressZip,
+                    AddressCountry = addressCountry,
+                    Phone = phone,
+                    Email = email,
+                    Metadata = metadata
+                });
+        }
+
+        public Task<LobResponse<AddressResource>> CreateAsync(CreateAddressRequest options)
+        {
+            return Client.ExecuteAsync<AddressResource>(
+                HttpMethod.Post,
+                Constants.AddressResourceEndpoint,
+                 HttpContentFactory.CreateJsonContent(options)
+                );
+        }
+    }
+}

--- a/Lob/Api/Address/AddressClient.cs
+++ b/Lob/Api/Address/AddressClient.cs
@@ -28,7 +28,6 @@ namespace Lob.Api.Address
 
         public Task<LobResponse<AddressResource>> GetAsync(string id)
         {
-            Console.WriteLine($"getasync {id}");
             return Client.ExecuteAsync<AddressResource>(
                 HttpMethod.Get,
                 $"{Constants.AddressResourceEndpoint}/{id}"

--- a/Lob/Api/Address/AddressResource.cs
+++ b/Lob/Api/Address/AddressResource.cs
@@ -1,0 +1,24 @@
+﻿using Lob.Api.Common;
+using System;
+using System.Collections.Generic;
+
+namespace Lob.Api.Address
+{
+    public class AddressResource : DeletableResource
+    {
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressCity { get; set; }
+        public string AddressState { get; set; }
+        public string AddressZip { get; set; }
+        public string AddressCountry { get; set; }
+        public string Company { get; set; }
+        public DateTime DateCreated { get; set; }
+        public DateTime DateModified { get; set; }
+        public string Description { get; set; }
+        public string Email { get; set; }
+        public IDictionary<string, string> Metadata { get; set; }
+        public string Name { get; set; }
+        public string Phone { get; set; }
+    }
+}

--- a/Lob/Api/Address/CreateAddressRequest.cs
+++ b/Lob/Api/Address/CreateAddressRequest.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace Lob.Api.Address
+{
+    public class CreateAddressRequest
+    {
+        public string Description { get; set; }
+        public string Name { get; set; }
+        public string Company { get; set; }
+        public string AddressLine1 { get; set; }
+        public string AddressLine2 { get; set; }
+        public string AddressCity { get; set; }
+        public string AddressState { get; set; }
+        public string AddressZip { get; set; }
+        public string AddressCountry { get; set; }
+        public string Phone { get; set; }
+        public string Email { get; set; }
+        public IDictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/Lob/Api/Common/DeletableResource.cs
+++ b/Lob/Api/Common/DeletableResource.cs
@@ -1,0 +1,9 @@
+﻿namespace Lob.Api.Common
+{
+    public class DeletableResource
+    {
+        public bool Deleted { get; set; }
+        public string Id { get; set; }
+        public string Object { get; set; }
+    }
+}

--- a/Lob/Api/Common/LobCollection.cs
+++ b/Lob/Api/Common/LobCollection.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Lob.Api.Common
+{
+    public class LobCollection<T>
+    {
+        public int Count { get; set; }
+        public IList<T> Data { get; set; }
+        public string Object { get; set; }
+    }
+}

--- a/Lob/Common/Constants.cs
+++ b/Lob/Common/Constants.cs
@@ -1,0 +1,16 @@
+﻿namespace Lob.Common
+{
+    public static class Constants
+    {
+        public const string ContentTypeJson = "application/json";
+
+        public const string UserAgentProductName = "Lob-DotNet";
+        public const string UserAgentProductVersion = "0.0.1";
+
+        public const string AddressResourceEndpoint = "addresses";
+        public const string LobApiBaseAddress = "https://api.lob.com/v1/";
+
+        public const string RateLimitHeaderPrefix = "rate-limit";
+        public static readonly string[] AllowedResponseHeaders = { Constants.RateLimitHeaderPrefix };
+    }
+}

--- a/Lob/Common/Utils/HttpContentFactory.cs
+++ b/Lob/Common/Utils/HttpContentFactory.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System.Net.Http;
+using System.Text;
+
+namespace Lob.Common.Utils
+{
+    public static class HttpContentFactory
+    {
+        public static HttpContent CreateJsonContent(object obj)
+        {
+            string body = JsonConvert.SerializeObject(obj, SerializerSettings.DefaultJsonSerializerSettings);
+            return new StringContent(body, Encoding.UTF8, Constants.ContentTypeJson);
+        }
+    }
+}

--- a/Lob/Common/Utils/SerializerSettings.cs
+++ b/Lob/Common/Utils/SerializerSettings.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Lob.Common.Utils
+{
+    public static class SerializerSettings
+    {
+        public static JsonSerializerSettings DefaultJsonSerializerSettings
+        {
+            get
+            {
+                return new JsonSerializerSettings()
+                {
+                    ContractResolver = new DefaultContractResolver() { NamingStrategy = new SnakeCaseNamingStrategy() },
+                    Formatting = Formatting.Indented
+                };
+            }
+        }
+    }
+}

--- a/Lob/Exceptions/LobException.cs
+++ b/Lob/Exceptions/LobException.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Lob.Exceptions
 {
-    class LobException : Exception
+   public class LobException : Exception
     {
         public LobException(string message, int httpStatusCode) : base(message)
         {
@@ -12,9 +12,9 @@ namespace Lob.Exceptions
 
         public int HttpStatusCode { get; private set; }
 
-        public static LobException Parse(string content)
+        public static LobException Parse(string json)
         {
-            JObject res = JObject.Parse(content);
+            JObject res = JObject.Parse(json);
             return new LobException(
                 message: res["error"]["message"].ToString(),
                 httpStatusCode: res["error"]["status_code"].ToObject<int>()

--- a/Lob/Exceptions/LobException.cs
+++ b/Lob/Exceptions/LobException.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+
+namespace Lob.Exceptions
+{
+    class LobException : Exception
+    {
+        public LobException(string message, int httpStatusCode) : base(message)
+        {
+            HttpStatusCode = httpStatusCode;
+        }
+
+        public int HttpStatusCode { get; private set; }
+
+        public static LobException Parse(string content)
+        {
+            JObject res = JObject.Parse(content);
+            return new LobException(
+                message: res["error"]["message"].ToString(),
+                httpStatusCode: res["error"]["status_code"].ToObject<int>()
+                );
+        }
+    }
+}
+

--- a/Lob/Lob.csproj
+++ b/Lob/Lob.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/Lob/Lob.csproj
+++ b/Lob/Lob.csproj
@@ -5,6 +5,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>

--- a/Lob/LobClient.cs
+++ b/Lob/LobClient.cs
@@ -1,0 +1,24 @@
+﻿using Lob.Api.Address;
+using Lob.Protocol;
+using System;
+
+namespace Lob
+{
+    public class LobClient
+    {
+        public LobClient(string apiKey)
+        {
+            if (String.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new ArgumentOutOfRangeException("ApiKey cannot be null or white space");
+            }
+
+            ApiKey = apiKey;
+        }
+
+        public AddressClient Address => new AddressClient(LobRestClient);
+
+        internal string ApiKey { get; private set; }
+        internal LobRestClient LobRestClient => new LobRestClient(ApiKey);
+    }
+}

--- a/Lob/Protocol/LobRequestOptions.cs
+++ b/Lob/Protocol/LobRequestOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace Lob.Protocol
+{
+    public class LobRequestOptions
+    {
+        // TODO: idempotency key, api-version, timeout, retry policy, etc.
+    }
+}

--- a/Lob/Protocol/LobResponse.cs
+++ b/Lob/Protocol/LobResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Lob.Protocol
+{
+    public class LobResponse<TResult>
+    {
+        public int HttpStatusCode { get; set; }
+        public IDictionary<string, string> Headers { get; set; }
+        public TResult Result { get; set; }
+    }
+}

--- a/Lob/Protocol/LobRestClient.cs
+++ b/Lob/Protocol/LobRestClient.cs
@@ -1,0 +1,84 @@
+﻿using Lob.Common;
+using Lob.Common.Utils;
+using Lob.Exceptions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lob.Protocol
+{
+    public class LobRestClient
+    {
+        public LobRestClient(string apiKey, HttpClient client = null)
+        {
+            // TODO: HttpClient should be reused across requests
+            // TODO: HttpClient should be disposed
+            Client = client ?? new HttpClient();
+            Client.BaseAddress = new Uri(Constants.LobApiBaseAddress);
+            Client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(Constants.UserAgentProductName, Constants.UserAgentProductVersion));
+            Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(Constants.ContentTypeJson));
+            Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(apiKey + ":")));
+        }
+
+        public HttpClient Client { get; private set; }
+
+        public async Task<LobResponse<TResult>> ExecuteAsync<TResult>(
+            HttpMethod method,
+            string requestUrl,
+            HttpContent content = null,
+            IDictionary<string, string> queryParams = null,
+            LobRequestOptions requestOptions = null)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(method, requestUrl);
+
+            if (content != null)
+            {
+                request.Content = content;
+            }
+
+            if (queryParams != null)
+            {
+                // TODO:
+            }
+
+            var response = await Client.SendAsync(request).ConfigureAwait(false);
+            return await ParseLobResponseAsync<TResult>(response);
+        }
+
+        private async Task<LobResponse<TResult>> ParseLobResponseAsync<TResult>(HttpResponseMessage response)
+        {
+            string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                LobException exception = null;
+
+                try
+                {
+                    exception = LobException.Parse(content);
+                }
+                catch (JsonException)
+                {
+                    exception = new LobException(message: content, httpStatusCode: (int)response.StatusCode);
+                }
+
+                throw exception;
+            }
+
+            return new LobResponse<TResult>
+            {
+                Result = JsonConvert.DeserializeObject<TResult>(content, SerializerSettings.DefaultJsonSerializerSettings),
+                HttpStatusCode = (int)response.StatusCode,
+                Headers = response.Headers
+                .Where(h => Constants.AllowedResponseHeaders.Any(pattern => h.Key.StartsWith(pattern, true, CultureInfo.InvariantCulture)))
+                .ToDictionary(h => h.Key, h => h.Value.FirstOrDefault())
+            };
+        }
+    }
+}

--- a/LobTest/AcceptanceTestBase.cs
+++ b/LobTest/AcceptanceTestBase.cs
@@ -1,0 +1,17 @@
+﻿using Lob;
+using NUnit.Framework;
+
+namespace LobTest
+{
+    [TestFixture(Category = "Acceptance")]
+    public abstract class AcceptanceTestBase
+    {
+        [SetUp]
+        public virtual void Setup()
+        {
+            LobClient = new LobClient("test_08423401b0a727b2301faf21570effdf984");
+        }
+
+        public LobClient LobClient { get; set; }
+    }
+}

--- a/LobTest/Api/Address/AddressClientAcceptanceTest.cs
+++ b/LobTest/Api/Address/AddressClientAcceptanceTest.cs
@@ -1,0 +1,140 @@
+﻿using Lob;
+using Lob.Api.Address;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LobTest.Api.Address
+{
+    public class AddressClientAcceptanceTest : AcceptanceTestBase
+    {
+        public readonly AddressResource ADDRESS = new AddressResource
+        {
+            Description = "Harry - Office",
+            Name = "HARRY",
+            Company = "COMPANY",
+            Email = "test@lob.com",
+            Phone = "some phone",
+            AddressLine1 = "185 BERRY ST STE 6100",
+            AddressCity = "SAN FRANCISCO",
+            AddressState = "CA",
+            AddressZip = "94107-1741",
+            AddressCountry = "UNITED STATES",
+            Metadata = new Dictionary<string, string>
+            {
+                ["foo"] = "bar",
+                ["fizz"] = "buzz"
+            },
+            Object = "address"
+        };
+
+        [Test]
+        public async Task TestCreateAsync()
+        {
+            var response = await LobClient.Address.CreateAsync(
+                description: ADDRESS.Description,
+                name: ADDRESS.Name,
+                company: ADDRESS.Company,
+                email: ADDRESS.Email,
+                phone: ADDRESS.Phone,
+                addressLine1: ADDRESS.AddressLine1,
+                addressCity: ADDRESS.AddressCity,
+                addressState: ADDRESS.AddressState,
+                addressZip: ADDRESS.AddressZip,
+                addressCountry: "US",
+                metadata: ADDRESS.Metadata
+            );
+
+            var address = response.Result;
+
+            Assert.AreEqual(200, response.HttpStatusCode);
+            StringAssert.AreEqualIgnoringCase(ADDRESS.Description, address.Description);
+            StringAssert.AreEqualIgnoringCase(ADDRESS.Name, address.Name);
+            StringAssert.AreEqualIgnoringCase(ADDRESS.Company, address.Company);
+            StringAssert.AreEqualIgnoringCase(ADDRESS.Email, address.Email);
+            StringAssert.AreEqualIgnoringCase(ADDRESS.Phone, address.Phone);
+            CollectionAssert.AreEquivalent(ADDRESS.Metadata, address.Metadata);
+            Assert.AreEqual(ADDRESS.AddressLine1, address.AddressLine1);
+            Assert.AreEqual(ADDRESS.AddressCity, address.AddressCity);
+            Assert.AreEqual(ADDRESS.AddressState, address.AddressState);
+            Assert.AreEqual(ADDRESS.AddressZip, address.AddressZip);
+            Assert.AreEqual(ADDRESS.AddressCountry, address.AddressCountry);
+            Assert.AreNotEqual(address.DateCreated, default(DateTime));
+            Assert.AreNotEqual(address.DateModified, default(DateTime));
+            Assert.IsFalse(String.IsNullOrEmpty(address.Id));
+            Assert.IsFalse(address.Deleted);
+            Assert.AreEqual(ADDRESS.Object, address.Object);
+        }
+
+        [Test]
+        public async Task TestDeleteAsync()
+        {
+            var address = (await LobClient.Address.CreateAsync(
+                new CreateAddressRequest()
+                {
+                    Description = ADDRESS.Description,
+                    Name = ADDRESS.Name,
+                    Company = ADDRESS.Company,
+                    Email = ADDRESS.Email,
+                    Phone = ADDRESS.Phone,
+                    AddressLine1 = ADDRESS.AddressLine1,
+                    AddressCity = ADDRESS.AddressCity,
+                    AddressState = ADDRESS.AddressState,
+                    AddressZip = ADDRESS.AddressZip,
+                    AddressCountry = "US",
+                    Metadata = ADDRESS.Metadata
+                }
+            )).Result;
+
+            var response = await LobClient.Address.DeleteAsync(address.Id);
+
+            Assert.AreEqual(200, response.HttpStatusCode);
+            Assert.AreEqual(address.Id, response.Result.Id);
+            Assert.True(response.Result.Deleted);
+        }
+
+        [Test]
+        public async Task TestGetAsync()
+        {
+            var address = (await LobClient.Address.ListAsync()).Result.Data.First();
+            var response = await LobClient.Address.GetAsync(address.Id);
+
+            Assert.AreEqual(200, response.HttpStatusCode);
+            AssertAddressEquals(address, response.Result);
+        }
+
+        [Test]
+        public async Task TestListAsync()
+        {
+            var response = await LobClient.Address.ListAsync();
+
+            Assert.AreEqual(200, response.HttpStatusCode);
+            Assert.GreaterOrEqual(response.Result.Data.Count, 1);
+            Assert.GreaterOrEqual(response.Result.Count, 1);
+            Assert.AreEqual("list", response.Result.Object);
+        }
+
+        private static void AssertAddressEquals(AddressResource x, AddressResource y)
+        {
+            Assert.AreEqual(x.Id, y.Id);
+            Assert.AreEqual(x.DateCreated, y.DateCreated);
+            Assert.AreEqual(x.DateModified, y.DateModified);
+            Assert.AreEqual(x.Deleted, y.Deleted);
+            Assert.AreEqual(x.Description, y.Description);
+            Assert.AreEqual(x.Email, y.Email);
+            Assert.AreEqual(x.Name, y.Name);
+            Assert.AreEqual(x.Object, y.Object);
+            Assert.AreEqual(x.Phone, y.Phone);
+            Assert.AreEqual(x.AddressCity, y.AddressCity);
+            Assert.AreEqual(x.AddressCountry, y.AddressCountry);
+            Assert.AreEqual(x.AddressLine1, y.AddressLine1);
+            Assert.AreEqual(x.AddressLine2, y.AddressLine2);
+            Assert.AreEqual(x.AddressState, y.AddressState);
+            Assert.AreEqual(x.AddressZip, y.AddressZip);
+            Assert.AreEqual(x.Company, y.Company);
+        }
+    }
+}
+

--- a/LobTest/Exceptions/LobExceptionTest.cs
+++ b/LobTest/Exceptions/LobExceptionTest.cs
@@ -1,0 +1,31 @@
+﻿using Lob.Exceptions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace LobTest.Exceptions
+{
+    [TestFixture]
+    class LobExceptionTest
+    {
+        [Test]
+        public void TestParseJson()
+        {
+            const string EXPECTED_MESSAGE = "expected_message";
+            const int EXPECTED_STATUS_CODE = 422;
+
+            var json = JsonConvert.SerializeObject(new
+            {
+                error = new
+                {
+                    message = EXPECTED_MESSAGE,
+                    status_code = EXPECTED_STATUS_CODE
+                }
+            });
+
+            LobException exception = LobException.Parse(json);
+
+            Assert.AreEqual(EXPECTED_MESSAGE, exception.Message);
+            Assert.AreEqual(EXPECTED_STATUS_CODE, exception.HttpStatusCode);
+        }
+    }
+}

--- a/LobTest/LobTest.csproj
+++ b/LobTest/LobTest.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="Api\Address\AddressClientAcceptanceTest.cs" />
     <Compile Include="AcceptanceTestBase.cs" />
+    <Compile Include="Exceptions\LobExceptionTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/LobTest/LobTest.csproj
+++ b/LobTest/LobTest.csproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.props" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B95B591D-B9C2-4CD5-943F-05F32374F33B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LobTest</RootNamespace>
+    <AssemblyName>LobTest</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.CodeCoverage.Shim, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeCoverage.1.0.3\lib\netstandard1.0\Microsoft.VisualStudio.CodeCoverage.Shim.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Api\Address\AddressClientAcceptanceTest.cs" />
+    <Compile Include="AcceptanceTestBase.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\lob\Lob.csproj">
+      <Project>{290f7ba4-aeeb-4054-9681-5d052db13a56}</Project>
+      <Name>Lob</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.10.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.targets" Condition="Exists('..\packages\Microsoft.NET.Test.Sdk.15.7.0\build\net45\Microsoft.Net.Test.Sdk.targets')" />
+</Project>

--- a/LobTest/Properties/AssemblyInfo.cs
+++ b/LobTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LobTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LobTest")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b95b591d-b9c2-4cd5-943f-05f32374f33b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/LobTest/packages.config
+++ b/LobTest/packages.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeCoverage" version="1.0.3" targetFramework="net461" />
+  <package id="Microsoft.NET.Test.Sdk" version="15.7.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
+  <package id="NUnit" version="3.10.1" targetFramework="net461" />
+  <package id="NUnit.Console" version="3.8.0" targetFramework="net461" />
+  <package id="NUnit.ConsoleRunner" version="3.8.0" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net461" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.3" targetFramework="net461" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.7.0" targetFramework="net461" />
+  <package id="NUnit3TestAdapter" version="3.10.0" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
**What:**
* Add initial directory structure, `sln` and `csproj` files for library and test.
* Add client library functionality to create/delete/get/list `addresses`.
  * list with parameters deferred until later.

**Details:**
* Usage:
```csharp
            // create address
            var response = await LobClient.Address.CreateAsync(
                description: ADDRESS.Description,
                name: ADDRESS.Name,
                company: ADDRESS.Company,
                email: ADDRESS.Email,
                phone: ADDRESS.Phone,
                addressLine1: ADDRESS.AddressLine1,
                addressCity: ADDRESS.AddressCity,
                addressState: ADDRESS.AddressState,
                addressZip: ADDRESS.AddressZip,
                addressCountry: "US", // so odd we can't put UNITED STATES here
                metadata: ADDRESS.Metadata
            );

            // access results
            var httpStatusCode = response.HttpStatusCode;
            var address = response.Result;

            // get address
            await LobClient.Address.GetAsync(id: address.Id);

            // delete address
            await LobClient.Address.DeleteAsync(id: address.Id);

            // list addresses
            await LobClient.Address.ListAsync();
```
* Overview:
  * `LobClient` is instantiated with the apiKey and is used to access the various API resources e.g. `LobClient.Address.CreateAsync(...)` or `LobClient.Letter.CreateAsync(...)` later
  * `LobRestClient` is a thin layer over `HttpClient` and does _only_ the following:
    * Query parameter handling (future)
    * Lob header handling (future)
    * Lob's API response handling (deserialization, error handling) 
  * Since `LobRestClient` has limited intelligence, it pushes content serialization and query parameter encoding to the resource client themselves (`AddressClient`, `LetterClient`, etc.). Not a big fan, but open to ideas. 
```csharp
        // LobRestClient.cs
        public async Task<LobResponse<TResult>> ExecuteAsync<TResult>(
            HttpMethod method,
            string requestUrl,
            HttpContent content = null,
            IDictionary<string, string> queryParams = null,
            LobRequestOptions requestOptions = null)
```
* Notes:
  * This version of the library uses `async` / `await`, so we do not support clients without said capability.
  * Since request and response have varying fields (especially for other mail types), the design is to use separate objects. e.g. 
```csharp
public Task<LobResponse<AddressResource>> CreateAsync(CreateAddressRequest options)
```` 
  * We won't know if this client structure will work going forward until we get to the more complicated types. e.g. Letters. Address is too simplistic. I can see challenges here:
    * Request/Response fields with multiple possible types. Object is the common denominator, but still need to think if that should be exposed to the end user. Also this will be interesting when it comes to serialization and content types.
    * Nested objects (inline address, fancy list filtering, etc.)