### PR TITLE
Fix metadata sort by

### DIFF
--- a/__tests__/Integration/BankAccountsApi.Spec.Test.cs
+++ b/__tests__/Integration/BankAccountsApi.Spec.Test.cs
@@ -25,7 +25,7 @@ namespace __tests__.Integration {
         private BankAccountsApi invalidApi;
         private BankAccountWritable bankAccountWritable;
         private BankAccountVerify verification;
-        private string createdId;
+        private List<string> idsToDelete;
 
         public BankAccountsApiTests()
         {
@@ -52,11 +52,13 @@ namespace __tests__.Integration {
             amounts.Add(35);
 
             verification = new BankAccountVerify(amounts);
+
+            idsToDelete = new List<string>();
         }
 
         public void Dispose()
         {
-            validApi.BankAccountDelete(createdId);
+            idsToDelete.ForEach(id => validApi.BankAccountDelete(id));
         }
 
         [Test]
@@ -64,9 +66,8 @@ namespace __tests__.Integration {
             BankAccount response = validApi.BankAccountCreate(bankAccountWritable);
 
             Assert.NotNull(response.Id);
+            idsToDelete.Add(response.Id);
             Assert.AreEqual(response.RoutingNumber, bankAccountWritable.RoutingNumber);
-
-            createdId = response.Id;
         }
 
         [Test]
@@ -93,10 +94,12 @@ namespace __tests__.Integration {
 
         [Test]
         public void BankAccountVerifyTest() {
-            BankAccount response = validApi.BankAccountVerify(createdId, verification);
+            BankAccount bankAccount = validApi.BankAccountCreate(bankAccountWritable);
+            idsToDelete.Add(bankAccount.Id);
+            BankAccount response = validApi.BankAccountVerify(bankAccount.Id, verification);
 
             Assert.NotNull(response);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, bankAccount.Id);
             Assert.True(response.Verified);
         }
 
@@ -113,8 +116,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void BankAccountVerifyTestBadUsername() {
+            BankAccount bankAccount = validApi.BankAccountCreate(bankAccountWritable);
+            idsToDelete.Add(bankAccount.Id);
             try {
-                BankAccount response = invalidApi.BankAccountVerify(createdId, verification);
+                BankAccount response = invalidApi.BankAccountVerify(bankAccount.Id, verification);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);
@@ -124,10 +129,12 @@ namespace __tests__.Integration {
 
         [Test]
         public void BankAccountRetrieveTest() {
-            BankAccount response = validApi.BankAccountRetrieve(createdId);
+            BankAccount bankAccount = validApi.BankAccountCreate(bankAccountWritable);
+            idsToDelete.Add(bankAccount.Id);
+            BankAccount response = validApi.BankAccountRetrieve(bankAccount.Id);
 
             Assert.NotNull(response.Id);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, bankAccount.Id);
         }
 
         [Test]
@@ -143,8 +150,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void BankAccountRetrieveTestBadUsername() {
+            BankAccount bankAccount = validApi.BankAccountCreate(bankAccountWritable);
+            idsToDelete.Add(bankAccount.Id);
             try {
-                BankAccount response = invalidApi.BankAccountRetrieve(createdId);
+                BankAccount response = invalidApi.BankAccountRetrieve(bankAccount.Id);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);
@@ -188,6 +197,7 @@ namespace __tests__.Integration {
             Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
+        */
 
         [Test]
         public void BankAccountListTestWithMetadataParameter() {
@@ -195,9 +205,7 @@ namespace __tests__.Integration {
             metadata.Add("name", "Harry");
 
             BankAccountList response = validApi.BankAccountsList(null, null, null, null, null, metadata);
-            Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
-        */
     }
 }

--- a/__tests__/Integration/BillingGroupsApi.Spec.Test.cs
+++ b/__tests__/Integration/BillingGroupsApi.Spec.Test.cs
@@ -25,7 +25,6 @@ namespace __tests__.Integration {
         private BillingGroupsApi invalidApi;
         private BillingGroupEditable billingGroupEditable;
         private BillingGroupEditable updatedBillingGroupEditable;
-        private string createdId;
 
         public BillingGroupsApiTests()
         {
@@ -60,8 +59,6 @@ namespace __tests__.Integration {
 
             Assert.NotNull(response.Id);
             Assert.AreEqual(response.Description, billingGroupEditable.Description);
-
-            createdId = response.Id;
         }
 
         [Test]
@@ -88,10 +85,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void BillingGroupUpdateTest() {
-            BillingGroup response = validApi.BillingGroupUpdate(createdId, updatedBillingGroupEditable);
+            BillingGroup bg = validApi.BillingGroupCreate(billingGroupEditable);
+            BillingGroup response = validApi.BillingGroupUpdate(bg.Id, updatedBillingGroupEditable);
 
             Assert.NotNull(response);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, bg.Id);
             Assert.AreEqual(response.Description, updatedBillingGroupEditable.Description);
         }
 
@@ -108,8 +106,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void BillingGroupUpdateTestBadUsername() {
+            BillingGroup bg = validApi.BillingGroupCreate(billingGroupEditable);
             try {
-                BillingGroup response = invalidApi.BillingGroupUpdate(createdId, updatedBillingGroupEditable);
+                BillingGroup response = invalidApi.BillingGroupUpdate(bg.Id, updatedBillingGroupEditable);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);
@@ -119,10 +118,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void BillingGroupRetrieveTest() {
-            BillingGroup response = validApi.BillingGroupRetrieve(createdId);
+            BillingGroup bg = validApi.BillingGroupCreate(billingGroupEditable);
+            BillingGroup response = validApi.BillingGroupRetrieve(bg.Id);
 
             Assert.NotNull(response.Id);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, bg.Id);
         }
 
         [Test]
@@ -138,8 +138,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void BillingGroupRetrieveTestBadUsername() {
+            BillingGroup bg = validApi.BillingGroupCreate(billingGroupEditable);
             try {
-                BillingGroup response = invalidApi.BillingGroupRetrieve(createdId);
+                BillingGroup response = invalidApi.BillingGroupRetrieve(bg.Id);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);
@@ -201,14 +202,14 @@ namespace __tests__.Integration {
             BillingGroupList response = validApi.BillingGroupsList(null, null, null, null, dateModified, null);
             Assert.Greater(response.Count, 0);
         }
+        */
 
         [Test]
+        [Ignore("Ignore until API fixed or docs updated")]
         public void BillingGroupListTestWithSortByParameter() {
-            SortBy5 sortBy = new SortBy5(null, SortBy5.SendDateEnum.Desc);
-
+            SortBy5 sortBy = new SortBy5(null, SortBy5.SendDateEnum.Asc);
             BillingGroupList response = validApi.BillingGroupsList(null, null, null, null, null, sortBy);
             Assert.Greater(response.Count, 0);
         }
-        */
     }
 }

--- a/__tests__/Integration/CardsApi.Spec.Test.cs
+++ b/__tests__/Integration/CardsApi.Spec.Test.cs
@@ -25,7 +25,7 @@ namespace __tests__.Integration {
         private CardsApi invalidApi;
         private CardEditable cardEditable;
         private CardUpdatable cardUpdatable;
-        private string createdId;
+        private List<string> idsToDelete;
 
         public CardsApiTests()
         {
@@ -48,11 +48,13 @@ namespace __tests__.Integration {
             cardUpdatable = new CardUpdatable(
                 "Updated card"
             );
+
+            idsToDelete = new List<string>();
         }
 
         public void Dispose()
         {
-            validApi.CardDelete(createdId);
+            idsToDelete.ForEach(id => validApi.CardDelete(id));
         }
 
         [Test]
@@ -60,9 +62,8 @@ namespace __tests__.Integration {
             Card response = validApi.CardCreate(cardEditable);
 
             Assert.NotNull(response.Id);
+            idsToDelete.Add(response.Id);
             Assert.AreEqual(response.Description, cardEditable.Description);
-
-            createdId = response.Id;
         }
 
         [Test]
@@ -89,10 +90,13 @@ namespace __tests__.Integration {
 
         [Test]
         public void CardRetrieveTest() {
-            Card response = validApi.CardRetrieve(createdId);
+            Card card = validApi.CardCreate(cardEditable);
+            idsToDelete.Add(card.Id);
+
+            Card response = validApi.CardRetrieve(card.Id);
 
             Assert.NotNull(response.Id);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, card.Id);
         }
 
         [Test]
@@ -108,8 +112,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void CardRetrieveTestBadUsername() {
+            Card card = validApi.CardCreate(cardEditable);
+            idsToDelete.Add(card.Id);
+
             try {
-                Card response = invalidApi.CardRetrieve(createdId);
+                Card response = invalidApi.CardRetrieve(card.Id);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);
@@ -132,20 +139,23 @@ namespace __tests__.Integration {
             Assert.AreEqual(response.Count, 2);
         }
 
-        // [Test]
-        // public void CardListTestWithSortByParameter() {
-        //     SortBy5 sortBy = new SortBy5(null, SortBy5.SendDateEnum.Desc);
-
-        //     CardList response = validApi.CardsList(null, null, null, sortBy);
-        //     Assert.Greater(response.Count, 0);
-        // }
+        [Test]
+        [Ignore("Ignore until API fixed or docs updated")]
+        public void CardListTestWithSortByParameter() {
+            SortBy5 sortBy = new SortBy5(null, SortBy5.SendDateEnum.Asc);
+            CardList response = validApi.CardsList(null, null, null, sortBy);
+            Assert.Greater(response.Count, 0);
+        }
 
         [Test]
         public void CardUpdateTest() {
-            Card response = validApi.CardUpdate(createdId, cardUpdatable);
+            Card card = validApi.CardCreate(cardEditable);
+            idsToDelete.Add(card.Id);
+
+            Card response = validApi.CardUpdate(card.Id, cardUpdatable);
 
             Assert.NotNull(response);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, card.Id);
             Assert.AreEqual(response.Description, cardUpdatable.Description);
         }
 
@@ -162,8 +172,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void CardUpdateTestBadUsername() {
+            Card card = validApi.CardCreate(cardEditable);
+            idsToDelete.Add(card.Id);
+
             try {
-                Card response = invalidApi.CardUpdate(createdId, cardUpdatable);
+                Card response = invalidApi.CardUpdate(card.Id, cardUpdatable);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);

--- a/__tests__/Integration/ChecksApi.Spec.Test.cs
+++ b/__tests__/Integration/ChecksApi.Spec.Test.cs
@@ -259,14 +259,11 @@ namespace __tests__.Integration {
             Assert.GreaterOrEqual(response.Count, 0);
         }
 
-        /*TODO: [DXP-1029]
         [Test]
         public void CheckListTestWithSortByParameter() {
             SortBy5 sortBy = new SortBy5(null, SortBy5.SendDateEnum.Asc);
-
             CheckList response = validApi.ChecksList(null, null, null, null, null, null, null, null, null, sortBy);
             Assert.Greater(response.Count, 0);
         }
-        */
     }
 }

--- a/__tests__/Integration/ChecksApi.Spec.Test.cs
+++ b/__tests__/Integration/ChecksApi.Spec.Test.cs
@@ -24,7 +24,7 @@ namespace __tests__.Integration {
         private ChecksApi validApi;
         private ChecksApi invalidApi;
         private CheckEditable checkEditable;
-        private string createdId;
+        private List<string> idsToDelete;
 
         private Address address1;
         private Address address2;
@@ -107,6 +107,8 @@ namespace __tests__.Integration {
                 null, // attachment
                 "check 1" // description
             );
+
+            idsToDelete = new List<string>();
         }
 
         public void Dispose()
@@ -114,7 +116,7 @@ namespace __tests__.Integration {
             validBankAccountsApi.BankAccountDelete(bankAccount.Id);
             validAddressesApi.AddressDelete(address1.Id);
             validAddressesApi.AddressDelete(address2.Id);
-            validApi.CheckCancel(createdId);
+            idsToDelete.ForEach(id => validApi.CheckCancel(id));
         }
 
         [Test]
@@ -122,9 +124,8 @@ namespace __tests__.Integration {
             Check response = validApi.CheckCreate(checkEditable);
 
             Assert.NotNull(response.Id);
+            idsToDelete.Add(response.Id);
             Assert.AreEqual(response.Description, checkEditable.Description);
-
-            createdId = response.Id;
         }
 
         [Test]
@@ -151,10 +152,12 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckRetrieveTest() {
-            Check response = validApi.CheckRetrieve(createdId);
+            Check check = validApi.CheckCreate(checkEditable);
+            idsToDelete.Add(check.Id);
+            Check response = validApi.CheckRetrieve(check.Id);
 
             Assert.NotNull(response.Id);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, check.Id);
         }
 
         [Test]
@@ -170,8 +173,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckRetrieveTestBadUsername() {
+            Check check = validApi.CheckCreate(checkEditable);
+            idsToDelete.Add(check.Id);
             try {
-                Check response = invalidApi.CheckRetrieve(createdId);
+                Check response = invalidApi.CheckRetrieve(check.Id);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);
@@ -215,6 +220,7 @@ namespace __tests__.Integration {
             Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
+        */
 
         [Test]
         public void CheckListTestWithMetadataParameter() {
@@ -222,10 +228,8 @@ namespace __tests__.Integration {
             metadata.Add("name", "Harry");
 
             CheckList response = validApi.ChecksList(null, null, null, null, null, metadata);
-            Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
-        */
 
         [Test]
         public void CheckListTestWithScheduledParameter() {

--- a/__tests__/Integration/LettersApi.Spec.Test.cs
+++ b/__tests__/Integration/LettersApi.Spec.Test.cs
@@ -24,7 +24,7 @@ namespace __tests__.Integration {
         private LettersApi validApi;
         private LettersApi invalidApi;
         private LetterEditable letterEditable;
-        private string createdId;
+        private List<string> idsToDelete;
 
         private Address address;
         private AddressesApi validAddressesApi;
@@ -33,7 +33,7 @@ namespace __tests__.Integration {
         {
             Configuration config = new Configuration();
             Configuration invalidConfig = new Configuration();
-            
+
             DotNetEnv.Env.TraversePath().Load();
             config.Username = System.Environment.GetEnvironmentVariable("LOB_API_TEST_KEY");
             invalidConfig.Username = "fake api key";
@@ -60,7 +60,7 @@ namespace __tests__.Integration {
             address = validAddressesApi.AddressCreate(addressEditable);
 
             Dictionary<string, string> metadata = new Dictionary<string, string>();
-            metadata.Add("internal_id", "fake internal id");
+            metadata.Add("name", "Harry");
 
             letterEditable = new LetterEditable(
                 null, // description
@@ -79,12 +79,14 @@ namespace __tests__.Integration {
                 "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf", // file
                 LetterEditable.ExtraServiceEnum.Certified // extraService
             );
+
+            idsToDelete = new List<string>();
         }
 
         public void Dispose()
         {
             validAddressesApi.AddressDelete(address.Id);
-            validApi.LetterCancel(createdId);
+            idsToDelete.ForEach(id => validApi.LetterCancel(id));
         }
 
         [Test]
@@ -92,9 +94,8 @@ namespace __tests__.Integration {
             Letter response = validApi.LetterCreate(letterEditable);
 
             Assert.NotNull(response.Id);
+            idsToDelete.Add(response.Id);
             Assert.AreEqual(response.Metadata, letterEditable.Metadata);
-
-            createdId = response.Id;
         }
 
         [Test]
@@ -121,10 +122,12 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterRetrieveTest() {
-            Letter response = validApi.LetterRetrieve(createdId);
+            Letter letter = validApi.LetterCreate(letterEditable);
+            idsToDelete.Add(letter.Id);
+            Letter response = validApi.LetterRetrieve(letter.Id);
 
             Assert.NotNull(response.Id);
-            Assert.AreEqual(response.Id, createdId);
+            Assert.AreEqual(response.Id, letter.Id);
         }
 
         [Test]
@@ -140,8 +143,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterRetrieveTestBadUsername() {
+            Letter letter = validApi.LetterCreate(letterEditable);
+            idsToDelete.Add(letter.Id);
             try {
-                Letter response = invalidApi.LetterRetrieve(createdId);
+                Letter response = invalidApi.LetterRetrieve(letter.Id);
             }
             catch (Exception e) {
                 Assert.IsInstanceOf<ApiException>(e);
@@ -185,17 +190,19 @@ namespace __tests__.Integration {
             Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
+        */
 
         [Test]
         public void LetterListTestWithMetadataParameter() {
+            Letter letter = validApi.LetterCreate(letterEditable);
+            idsToDelete.Add(letter.Id);
+
             Dictionary<String, String> metadata = new Dictionary<String, String>();
             metadata.Add("name", "Harry");
 
             LetterList response = validApi.LettersList(null, null, null, null, null, metadata);
-            Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
-        */
 
         [Test]
         public void LetterListTestWithColorParameter() {

--- a/__tests__/Integration/LettersApi.Spec.Test.cs
+++ b/__tests__/Integration/LettersApi.Spec.Test.cs
@@ -240,7 +240,6 @@ namespace __tests__.Integration {
             Assert.GreaterOrEqual(response.Count, 0);
         }
 
-        /* TODO: [DXP-1129]
         [Test]
         public void LetterListTestWithSortByParameter() {
             SortBy5 sortBy = new SortBy5(null, SortBy5.SendDateEnum.Asc);
@@ -248,6 +247,5 @@ namespace __tests__.Integration {
             LetterList response = validApi.LettersList(null, null, null, null, null, null, null, null, null, null, sortBy);
             Assert.Greater(response.Count, 0);
         }
-        */
     }
 }

--- a/__tests__/Integration/PostcardsApi.Spec.Test.cs
+++ b/__tests__/Integration/PostcardsApi.Spec.Test.cs
@@ -58,9 +58,6 @@ namespace __tests__.Integration {
             validAddressesApi = new AddressesApi(config);
             address = validAddressesApi.AddressCreate(addressEditable);
 
-            Dictionary<string, string> metadata = new Dictionary<string, string>();
-            metadata.Add("internal_id", "fake internal id");
-
             postcardEditable = new PostcardEditable(
                 address.Id, // to
                 address.Id, // from
@@ -75,7 +72,7 @@ namespace __tests__.Integration {
                 default(string) // billingGroupId
             );
             postcardEditable.Metadata = new Dictionary<string, string>();
-            postcardEditable.Metadata.Add("fake campaign", "fakeid");
+            postcardEditable.Metadata.Add("name", "Harry");
 
             idsToDelete = new List<string>();
         }
@@ -189,17 +186,20 @@ namespace __tests__.Integration {
             Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
+        */
 
         [Test]
         public void PostcardListTestWithMetadataParameter() {
+            Postcard createdPostcard = validApi.PostcardCreate(postcardEditable);
+            idsToDelete.Add(createdPostcard.Id);
+
             Dictionary<String, String> metadata = new Dictionary<String, String>();
             metadata.Add("name", "Harry");
 
             PostcardList response = validApi.PostcardsList(null, null, null, null, null, metadata, null, null, null, null, null);
-            Console.WriteLine(response);
             Assert.Greater(response.Count, 0);
         }
-        */
+
 
         /* TODO [DXP-1128]: fix how Lob API wants an array of PostcardSize but the SDK accepts just PostcardSize
         [Test]

--- a/__tests__/Integration/PostcardsApi.Spec.Test.cs
+++ b/__tests__/Integration/PostcardsApi.Spec.Test.cs
@@ -239,7 +239,6 @@ namespace __tests__.Integration {
             Assert.GreaterOrEqual(response.Count, 0);
         }
 
-        /*
         [Test]
         public void PostcardListTestWithSortByParameter() {
             SortBy5 sortBy = new SortBy5(null, SortBy5.SendDateEnum.Asc);
@@ -247,7 +246,6 @@ namespace __tests__.Integration {
             PostcardList response = validApi.PostcardsList(null, null, null, null, null, null, null, null, null, null, sortBy);
             Assert.Greater(response.Count, 0);
         }
-        */
 
         [Test]
         public void PostcardDeleteTest() {

--- a/src/lob.dotnet/Api/AddressesApi.cs
+++ b/src/lob.dotnet/Api/AddressesApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -1020,7 +1020,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
 
             localVarRequestOptions.Operation = "AddressesApi.AddressesList";

--- a/src/lob.dotnet/Api/BankAccountsApi.cs
+++ b/src/lob.dotnet/Api/BankAccountsApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -533,8 +533,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -1024,8 +1024,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -1150,7 +1150,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
 
             localVarRequestOptions.Operation = "BankAccountsApi.BankAccountsList";
@@ -1256,7 +1256,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
 
             localVarRequestOptions.Operation = "BankAccountsApi.BankAccountsList";

--- a/src/lob.dotnet/Api/BillingGroupsApi.cs
+++ b/src/lob.dotnet/Api/BillingGroupsApi.cs
@@ -946,7 +946,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "BillingGroupsApi.BillingGroupsList";
@@ -1052,7 +1052,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "BillingGroupsApi.BillingGroupsList";

--- a/src/lob.dotnet/Api/CardsApi.cs
+++ b/src/lob.dotnet/Api/CardsApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -525,8 +525,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -1016,8 +1016,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -1130,7 +1130,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "CardsApi.CardsList";
@@ -1224,7 +1224,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "CardsApi.CardsList";

--- a/src/lob.dotnet/Api/ChecksApi.cs
+++ b/src/lob.dotnet/Api/ChecksApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -665,8 +665,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -958,7 +958,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (scheduled != null)
             {
@@ -1088,7 +1088,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (scheduled != null)
             {

--- a/src/lob.dotnet/Api/ChecksApi.cs
+++ b/src/lob.dotnet/Api/ChecksApi.cs
@@ -974,7 +974,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "ChecksApi.ChecksList";
@@ -1104,7 +1104,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "ChecksApi.ChecksList";

--- a/src/lob.dotnet/Api/LettersApi.cs
+++ b/src/lob.dotnet/Api/LettersApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -669,8 +669,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -964,7 +964,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (color != null)
             {
@@ -1100,7 +1100,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (color != null)
             {

--- a/src/lob.dotnet/Api/LettersApi.cs
+++ b/src/lob.dotnet/Api/LettersApi.cs
@@ -984,7 +984,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "LettersApi.LettersList";
@@ -1120,7 +1120,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "LettersApi.LettersList";

--- a/src/lob.dotnet/Api/PostcardsApi.cs
+++ b/src/lob.dotnet/Api/PostcardsApi.cs
@@ -984,7 +984,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "PostcardsApi.PostcardsList";
@@ -1120,7 +1120,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "PostcardsApi.PostcardsList";

--- a/src/lob.dotnet/Api/PostcardsApi.cs
+++ b/src/lob.dotnet/Api/PostcardsApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -513,8 +513,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -964,7 +964,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (size != null)
             {
@@ -984,7 +984,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy));
             }
 
             localVarRequestOptions.Operation = "PostcardsApi.PostcardsList";
@@ -1100,7 +1100,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (size != null)
             {

--- a/src/lob.dotnet/Api/SelfMailersApi.cs
+++ b/src/lob.dotnet/Api/SelfMailersApi.cs
@@ -984,7 +984,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "SelfMailersApi.SelfMailersList";
@@ -1120,7 +1120,7 @@ namespace lob.dotnet.Api
             }
             if (sortBy != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "sort_by", sortBy));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "sort_by", sortBy.ToJson()));
             }
 
             localVarRequestOptions.Operation = "SelfMailersApi.SelfMailersList";

--- a/src/lob.dotnet/Api/SelfMailersApi.cs
+++ b/src/lob.dotnet/Api/SelfMailersApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -513,8 +513,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -964,7 +964,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (size != null)
             {
@@ -1100,7 +1100,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
             if (size != null)
             {

--- a/src/lob.dotnet/Api/TemplatesApi.cs
+++ b/src/lob.dotnet/Api/TemplatesApi.cs
@@ -1,7 +1,7 @@
 /*
  * Lob
  *
- * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)? 
+ * The Lob API is organized around REST. Our API is designed to have predictable, resource-oriented URLs and uses HTTP response codes to indicate any API errors. <p> Looking for our [previous documentation](https://lob.github.io/legacy-docs/)?
  *
  * The version of the OpenAPI document: 1.3.0
  * Contact: lob-openapi@lob.com
@@ -533,8 +533,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -1024,8 +1024,8 @@ namespace lob.dotnet.Api
             lob.dotnet.Client.RequestOptions localVarRequestOptions = new lob.dotnet.Client.RequestOptions();
 
             string[] _contentTypes = new string[] {
-                "application/json", 
-                "application/x-www-form-urlencoded", 
+                "application/json",
+                "application/x-www-form-urlencoded",
                 "multipart/form-data"
             };
 
@@ -1150,7 +1150,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
 
             localVarRequestOptions.Operation = "TemplatesApi.TemplatesList";
@@ -1256,7 +1256,7 @@ namespace lob.dotnet.Api
             }
             if (metadata != null)
             {
-                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("", "metadata", metadata));
+                localVarRequestOptions.QueryParameters.Add(lob.dotnet.Client.ClientUtils.ParameterToMultiMap("deepObject", "metadata", metadata));
             }
 
             localVarRequestOptions.Operation = "TemplatesApi.TemplatesList";


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-1129)

Improved some integration tests that were creating just one resource for the whole test file rather than creating the resource for each relevant test -- isolates everything.

Uncommented the metadata and sortBy tests.

## Concerns
There still seems to be a problem with using those params in BillingGroupsList and CardsList. I tried with CURL too but it says that `sort_by` or `sort_by,send_date` isn't allowed. Don't know who I should go to about it but it looks like our docs will need to be updated if this is expected behavior.

## Relevant PRs
changes spec: 
[metadata change](https://github.com/lob/sdks_openapi_gen/pull/246)
[sort_by change](https://github.com/lob/sdks_openapi_gen/pull/247)