### PR TITLE
Additional target

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,6 +1,7 @@
 name: Run Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened, edited]
     branches:

--- a/src/lob.dotnet/Client/TolerantEnumConverter.cs
+++ b/src/lob.dotnet/Client/TolerantEnumConverter.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq;
-using System.Text.Json.Serialization;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 class TolerantEnumConverter : Newtonsoft.Json.JsonConverter
 {

--- a/src/lob.dotnet/lob.dotnet.csproj
+++ b/src/lob.dotnet/lob.dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo><!-- setting GenerateAssemblyInfo to false causes this bug https://github.com/dotnet/project-system/issues/3934 -->
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <AssemblyName>lob.dotnet</AssemblyName>
     <PackageId>lob.dotnet</PackageId>
     <OutputType>Library</OutputType>
@@ -11,7 +11,7 @@
     <AssemblyTitle>OpenAPI Library</AssemblyTitle>
     <Description>A library generated from a OpenAPI spec for the Csharp language</Description>
     <RootNamespace>lob.dotnet</RootNamespace>
-    <Version>1.1.3</Version>
+    <Version>1.1.4-beta</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\lob.dotnet.xml</DocumentationFile>
     <RepositoryUrl>https://github.com/lob/lob-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
Added support for netstandard2.0 to allow the package to be used with 472 projects as mentioned in #35