### PR TITLE
PLAT-2193: update deprecated GitHub Actions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,11 +14,11 @@ jobs:
         dotnet-version: ['3.1.x']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install dependencies

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, reopened, edited]
     branches:
-      - main
+      - '*'
 jobs:
   build:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,9 +2,9 @@ name: Run Tests
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, ready_for_review]
     branches:
-      - '*'
+      - main
 jobs:
   build:
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,4 +28,3 @@ jobs:
         env:
           LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
           LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}
-


### PR DESCRIPTION
## JIRA

* [PLAT-2193](https://lobsters.atlassian.net/browse/PLAT-2193)

## Description

* Updating deprecated GitHub actions:
  * `actions/checkout@v3` and `actions/setup-dotnet@v2` run Node 16 and are deprecated, we need them to run Node 20:

See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

![image](https://github.com/lob/lob-dotnet/assets/117756379/b5a12b28-1e2f-458f-8bef-062df9df5277)

---

* Removing `dotnet-version` as it is not a valid parameter for [`actions/checkout`](https://github.com/actions/checkout) which will get rid of these warnings:

![image](https://github.com/lob/lob-dotnet/assets/117756379/7b3826dc-208e-4341-940e-0a3e09a2d08a)

---

[PLAT-2193]: https://lobsters.atlassian.net/browse/PLAT-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ