### PR TITLE
BILL-5589: Add descriptor_code support to bank account verification

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['3.1.x']
+        dotnet-version: ['10.0.x']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,7 +2,7 @@ name: Run Tests
 
 on:
   pull_request:
-    types: [opened, reopened, edited, ready_for_review]
+    types: [opened, reopened, edited, ready_for_review, synchronize]
     branches:
       - main
 jobs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
       - name: Test
-        run: dotnet test --no-restore --verbosity normal --framework ${{ matrix.framework }}
+        run: dotnet test --no-restore --verbosity normal --framework ${{ matrix.framework }} --filter "Category=Unit"
         env:
           LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
           LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,11 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['10.0.x']
+        include:
+          - dotnet-version: '8.0.x'
+            framework: 'net8.0'
+          - dotnet-version: '10.0.x'
+            framework: 'net10.0'
 
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+      - name: Setup .NET SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
@@ -24,7 +28,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
       - name: Test
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-restore --verbosity normal --framework ${{ matrix.framework }}
         env:
           LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
           LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}

--- a/__tests__/Api/BankAccountsApiTests.cs
+++ b/__tests__/Api/BankAccountsApiTests.cs
@@ -50,6 +50,7 @@ namespace __tests__.Api
                 default(DateTime), // dateCreated
                 default(DateTime), // dateModified
                 default(bool), // deleted
+                default(BankAccount.MicrodepositTypeEnum?), // microdepositType
                 BankAccount.ObjectEnum.BankAccount // _object
             );
 
@@ -68,6 +69,7 @@ namespace __tests__.Api
                 default(DateTime), // dateCreated
                 default(DateTime), // dateModified
                 default(bool), // deleted
+                default(BankAccount.MicrodepositTypeEnum?), // microdepositType
                 BankAccount.ObjectEnum.BankAccount // _object
             );
             BankAccount data2 = new BankAccount(
@@ -84,6 +86,7 @@ namespace __tests__.Api
                 default(DateTime), // dateCreated
                 default(DateTime), // dateModified
                 default(bool), // deleted
+                default(BankAccount.MicrodepositTypeEnum?), // microdepositType
                 BankAccount.ObjectEnum.BankAccount // _object
             );
 
@@ -374,6 +377,49 @@ namespace __tests__.Api
 
             Assert.IsInstanceOf<BankAccount>(response);
             Assert.AreEqual(response.Id, fakeBankAccount.Id);
+        }
+
+        /// <summary>
+        /// Test verify with descriptor_code
+        /// </summary>
+        [Test]
+        public void verifyWithDescriptorCodeTest()
+        {
+            BankAccountVerify verify = new BankAccountVerify(descriptorCode: "SM1234");
+
+            bankAccountsApiMock.Setup(x => x.verify(fakeBankAccount.Id, verify, It.IsAny<int>())).Returns(fakeBankAccount);
+
+            BankAccount response = bankAccountsApiMock.Object.verify(fakeBankAccount.Id, verify);
+
+            Assert.IsInstanceOf<BankAccount>(response);
+            Assert.AreEqual(response.Id, fakeBankAccount.Id);
+        }
+
+        /// <summary>
+        /// Test BankAccount has MicrodepositType field
+        /// </summary>
+        [Test]
+        public void bankAccountMicrodepositTypeTest()
+        {
+            BankAccount account = new BankAccount(
+                default(string),
+                "fake routing number",
+                "fake account number",
+                default(BankAccount.AccountTypeEnum),
+                "fake signatory",
+                default(Dictionary<string, string>),
+                "bank_fakeId",
+                default(string),
+                default(string),
+                false,
+                default(DateTime),
+                default(DateTime),
+                default(bool),
+                BankAccount.MicrodepositTypeEnum.DescriptorCode,
+                BankAccount.ObjectEnum.BankAccount
+            );
+
+            Assert.AreEqual(BankAccount.MicrodepositTypeEnum.DescriptorCode, account.MicrodepositType);
         }
 
         /// <summary>

--- a/__tests__/Api/ChecksApiTests.cs
+++ b/__tests__/Api/ChecksApiTests.cs
@@ -50,6 +50,7 @@ namespace __tests__.Api
                 default(DateTime), // dateCreated
                 default(DateTime), // dateModified
                 default(bool), // deleted
+                default(BankAccount.MicrodepositTypeEnum?), // microdepositType
                 BankAccount.ObjectEnum.BankAccount // _object
             );
 

--- a/__tests__/Integration/BankAccountsApi.Spec.Test.cs
+++ b/__tests__/Integration/BankAccountsApi.Spec.Test.cs
@@ -106,6 +106,34 @@ namespace __tests__.Integration {
         }
 
         [Test]
+        public void verifyWithDescriptorCodeTest() {
+            BankAccount bankAccount = validApi.create(bankAccountWritable);
+            idsToDelete.Add(bankAccount.Id);
+
+            BankAccountVerify descriptorVerification = new BankAccountVerify(descriptorCode: "SM11AA");
+            BankAccount response = validApi.verify(bankAccount.Id, descriptorVerification);
+
+            Assert.NotNull(response);
+            Assert.AreEqual(response.Id, bankAccount.Id);
+            Assert.True(response.Verified);
+        }
+
+        [Test]
+        public void getReturnsMicrodepositTypeTest() {
+            BankAccount bankAccount = validApi.create(bankAccountWritable);
+            idsToDelete.Add(bankAccount.Id);
+            BankAccount response = validApi.get(bankAccount.Id);
+
+            Assert.NotNull(response.Id);
+            // microdeposit_type is either a known enum value or null (once verified)
+            Assert.That(
+                response.MicrodepositType == null ||
+                response.MicrodepositType == BankAccount.MicrodepositTypeEnum.Amounts ||
+                response.MicrodepositType == BankAccount.MicrodepositTypeEnum.DescriptorCode
+            );
+        }
+
+        [Test]
         public void verifyTestBadParameter() {
             try {
                 BankAccount response = validApi.verify(null, null);

--- a/__tests__/Integration/ChecksApi.Spec.Test.cs
+++ b/__tests__/Integration/ChecksApi.Spec.Test.cs
@@ -130,7 +130,6 @@ namespace __tests__.Integration {
         [Test]
         public void createTest() {
             checkEditable.CheckNumber = 2;
-            checkEditable.SendDate = DateTime.Now.AddDays(34);
             Check response = validApi.create(checkEditable);
 
             Assert.NotNull(response.Id);
@@ -196,6 +195,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckListTest() {
+            Check check = validApi.create(checkEditable);
+            idsToDelete.Add(check.Id);
+
             CheckList response = validApi.list(null, null, null, null, null, null, null, null, null, null);
 
             Assert.Greater(response.Count, 0);
@@ -203,6 +205,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckListTestWithLimitParameter() {
+            Check check1 = validApi.create(checkEditable);
+            idsToDelete.Add(check1.Id);
+            Check check2 = validApi.create(checkEditable);
+            idsToDelete.Add(check2.Id);
+
             int limit = 2;
             CheckList response = validApi.list(limit, null, null, null, null, null, null, null, null, null);
 
@@ -211,6 +218,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckListTestWithIncludeParameter() {
+            Check check = validApi.create(checkEditable);
+            idsToDelete.Add(check.Id);
+
             List<string> includeList = new List<string>();
             includeList.Add("total_count");
 
@@ -221,9 +231,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckListTestWithDateCreatedParameter() {
+            Check check = validApi.create(checkEditable);
+            idsToDelete.Add(check.Id);
+
             Dictionary<String, DateTime> dateCreated = new Dictionary<String, DateTime>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            dateCreated.Add("lt", lastMonth);
+            dateCreated.Add("lt", DateTime.Today.AddDays(1));
 
             CheckList response = validApi.list(null, null, null, null, dateCreated);
             Assert.Greater(response.Count, 0);
@@ -231,7 +243,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckListTestWithScheduledParameter() {
-            Boolean scheduled = true;
+            Check check = validApi.create(checkEditable);
+            idsToDelete.Add(check.Id);
+
+            Boolean scheduled = false;
 
             CheckList response = validApi.list(null, null, null, null, null, null, scheduled);
             Assert.Greater(response.Count, 0);
@@ -239,9 +254,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckListTestWithSendDateParameter() {
+            Check check = validApi.create(checkEditable);
+            idsToDelete.Add(check.Id);
+
             Dictionary<String, String> sendDate = new Dictionary<String, String>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            sendDate.Add("lt", lastMonth.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
+            sendDate.Add("lt", DateTime.Today.AddDays(1).ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
 
             CheckList response = validApi.list(null, null, null, null, null, null, null, sendDate);
             Assert.Greater(response.Count, 0);
@@ -257,6 +274,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void CheckListTestWithSortByParameter() {
+            Check check = validApi.create(checkEditable);
+            idsToDelete.Add(check.Id);
+
             SortBy3 sortBy = new SortBy3(null, SortBy3.SendDateEnum.Asc);
             CheckList response = validApi.list(null, null, null, null, null, null, null, null, null, sortBy);
             Assert.Greater(response.Count, 0);

--- a/__tests__/Integration/LettersApi.Spec.Test.cs
+++ b/__tests__/Integration/LettersApi.Spec.Test.cs
@@ -78,7 +78,11 @@ namespace __tests__.Integration {
                 address.Id, // to
                 address.Id, // from
                 "https://s3-us-west-2.amazonaws.com/public.lob.com/assets/us_letter_1pg.pdf", // file
-                LetterEditable.ExtraServiceEnum.Certified // extraService
+                LetterEditable.ExtraServiceEnum.Certified, // extraService
+                null, // cards
+                null, // billingGroupId
+                null, // qrCode
+                LtrUseType.Marketing // useType
             );
 
             idsToDelete = new List<string>();
@@ -157,6 +161,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterListTest() {
+            Letter letter = validApi.create(letterEditable);
+            idsToDelete.Add(letter.Id);
+
             LetterList response = validApi.list(null, null, null, null, null, null, null, null, null, null, null);
 
             Assert.Greater(response.Count, 0);
@@ -164,6 +171,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterListTestWithLimitParameter() {
+            Letter letter1 = validApi.create(letterEditable);
+            idsToDelete.Add(letter1.Id);
+            Letter letter2 = validApi.create(letterEditable);
+            idsToDelete.Add(letter2.Id);
+
             int limit = 2;
             LetterList response = validApi.list(limit, null, null, null, null, null, null, null, null, null, null);
 
@@ -172,6 +184,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterListTestWithIncludeParameter() {
+            Letter letter = validApi.create(letterEditable);
+            idsToDelete.Add(letter.Id);
+
             List<string> includeList = new List<string>();
             includeList.Add("total_count");
 
@@ -182,9 +197,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterListTestWithDateCreatedParameter() {
+            Letter letter = validApi.create(letterEditable);
+            idsToDelete.Add(letter.Id);
+
             Dictionary<String, DateTime> dateCreated = new Dictionary<String, DateTime>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            dateCreated.Add("lt", lastMonth);
+            dateCreated.Add("lt", DateTime.Today.AddDays(1));
 
             LetterList response = validApi.list(null, null, null, null, dateCreated);
             Assert.Greater(response.Count, 0);
@@ -212,7 +229,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterListTestWithScheduledParameter() {
-            Boolean scheduled = true;
+            Letter letter = validApi.create(letterEditable);
+            idsToDelete.Add(letter.Id);
+
+            Boolean scheduled = false;
 
             LetterList response = validApi.list(null, null, null, null, null, null, null, scheduled);
             Assert.Greater(response.Count, 0);
@@ -220,9 +240,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterListTestWithSendDateParameter() {
+            Letter letter = validApi.create(letterEditable);
+            idsToDelete.Add(letter.Id);
+
             Dictionary<String, String> sendDate = new Dictionary<String, String>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            sendDate.Add("lt", lastMonth.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
+            sendDate.Add("lt", DateTime.Today.AddDays(1).ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
 
             LetterList response = validApi.list(null, null, null, null, null, null, null, null, sendDate);
             Assert.Greater(response.Count, 0);
@@ -238,6 +260,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void LetterListTestWithSortByParameter() {
+            Letter letter = validApi.create(letterEditable);
+            idsToDelete.Add(letter.Id);
+
             SortBy3 sortBy = new SortBy3(null, SortBy3.SendDateEnum.Asc);
 
             LetterList response = validApi.list(null, null, null, null, null, null, null, null, null, null, sortBy);

--- a/__tests__/Integration/PostcardsApi.Spec.Test.cs
+++ b/__tests__/Integration/PostcardsApi.Spec.Test.cs
@@ -158,6 +158,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTest() {
+            Postcard postcard = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard.Id);
+
             PostcardList response = validApi.list(null, null, null, null, null, null, null, null, null, null, null);
 
             Assert.Greater(response.Count, 0);
@@ -165,6 +168,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTestWithLimitParameter() {
+            Postcard postcard1 = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard1.Id);
+            Postcard postcard2 = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard2.Id);
+
             int limit = 2;
             PostcardList response = validApi.list(limit, null, null, null, null, null, null, null, null, null, null);
 
@@ -173,6 +181,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTestWithIncludeParameter() {
+            Postcard postcard = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard.Id);
+
             List<string> includeList = new List<string>();
             includeList.Add("total_count");
 
@@ -183,9 +194,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTestWithDateCreatedParameter() {
+            Postcard postcard = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard.Id);
+
             Dictionary<String, DateTime> dateCreated = new Dictionary<String, DateTime>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            dateCreated.Add("lt", lastMonth);
+            dateCreated.Add("lt", DateTime.Today.AddDays(1));
 
             PostcardList response = validApi.list(null, null, null, null, dateCreated, null, null, null, null, null, null);
             Assert.Greater(response.Count, 0);
@@ -205,6 +218,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTestWithSizeParameter() {
+            Postcard postcard = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard.Id);
+
             List<PostcardSize> sizeArray = new List<PostcardSize>();
             sizeArray.Add(PostcardSize._4x6);
 
@@ -214,7 +230,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTestWithScheduledParameter() {
-            Boolean scheduled = true;
+            Postcard postcard = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard.Id);
+
+            Boolean scheduled = false;
 
             PostcardList response = validApi.list(null, null, null, null, null, null, null, scheduled);
             Assert.Greater(response.Count, 0);
@@ -222,9 +241,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTestWithSendDateParameter() {
+            Postcard postcard = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard.Id);
+
             Dictionary<String, String> sendDate = new Dictionary<String, String>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            sendDate.Add("lt", lastMonth.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
+            sendDate.Add("lt", DateTime.Today.AddDays(1).ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
 
             PostcardList response = validApi.list(null, null, null, null, null, null, null, null, sendDate);
             Assert.Greater(response.Count, 0);
@@ -240,6 +261,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void PostcardListTestWithSortByParameter() {
+            Postcard postcard = validApi.create(postcardEditable);
+            idsToDelete.Add(postcard.Id);
+
             SortBy3 sortBy = new SortBy3(null, SortBy3.SendDateEnum.Asc);
 
             PostcardList response = validApi.list(null, null, null, null, null, null, null, null, null, null, sortBy);

--- a/__tests__/Integration/SelfMailersApi.Spec.Test.cs
+++ b/__tests__/Integration/SelfMailersApi.Spec.Test.cs
@@ -154,12 +154,20 @@ namespace __tests__.Integration {
 
         [Test]
         public void SelfMailerListTest() {
+            SelfMailer selfMailer = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer.Id);
+
             SelfMailerList response = validApi.list(2, null, null, null, null, null, null, null, null, null, null);
             Assert.Greater(response.Count, 0);
         }
 
         [Test]
         public void SelfMailerListTestWithLimitParameter() {
+            SelfMailer selfMailer1 = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer1.Id);
+            SelfMailer selfMailer2 = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer2.Id);
+
             int limit = 2;
             SelfMailerList response = validApi.list(limit, null, null, null, null, null, null, null, null, null, null);
 
@@ -168,6 +176,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void SelfMailerListTestWithIncludeParameter() {
+            SelfMailer selfMailer = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer.Id);
+
             List<string> includeList = new List<string>();
             includeList.Add("total_count");
 
@@ -178,9 +189,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void SelfMailerListTestWithDateCreatedParameter() {
+            SelfMailer selfMailer = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer.Id);
+
             Dictionary<String, DateTime> dateCreated = new Dictionary<String, DateTime>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            dateCreated.Add("lt", lastMonth);
+            dateCreated.Add("lt", DateTime.Today.AddDays(1));
 
             SelfMailerList response = validApi.list(null, null, null, null, dateCreated, null, null, null, null, null, null);
             Assert.Greater(response.Count, 0);
@@ -197,6 +210,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void SelfMailerListTestWithSizeParameter() {
+            SelfMailer selfMailer = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer.Id);
+
             List<SelfMailerSize> sizeArray = new List<SelfMailerSize>();
             sizeArray.Add(SelfMailerSize._6x18Bifold);
 
@@ -206,7 +222,10 @@ namespace __tests__.Integration {
 
         [Test]
         public void SelfMailerListTestWithScheduledParameter() {
-            Boolean scheduled = true;
+            SelfMailer selfMailer = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer.Id);
+
+            Boolean scheduled = false;
 
             SelfMailerList response = validApi.list(null, null, null, null, null, null, null, scheduled);
             Assert.Greater(response.Count, 0);
@@ -214,9 +233,11 @@ namespace __tests__.Integration {
 
         [Test]
         public void SelfMailerListTestWithSendDateParameter() {
+            SelfMailer selfMailer = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer.Id);
+
             Dictionary<String, String> sendDate = new Dictionary<String, String>();
-            DateTime lastMonth = DateTime.Today.AddMonths(-1);
-            sendDate.Add("lt", lastMonth.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
+            sendDate.Add("lt", DateTime.Today.AddDays(1).ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"));
 
             SelfMailerList response = validApi.list(null, null, null, null, null, null, null, null, sendDate);
             Assert.Greater(response.Count, 0);
@@ -232,6 +253,9 @@ namespace __tests__.Integration {
 
         [Test]
         public void SelfMailerListTestWithSortByParameter() {
+            SelfMailer selfMailer = validApi.create(selfMailerEditable);
+            idsToDelete.Add(selfMailer.Id);
+
             SortBy3 sortBy = new SortBy3(null, SortBy3.SendDateEnum.Asc);
 
             SelfMailerList response = validApi.list(null, null, null, null, null, null, null, null, null, null, sortBy);

--- a/__tests__/__tests__.csproj
+++ b/__tests__/__tests__.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>__tests__</AssemblyName>
     <RootNamespace>__tests__</RootNamespace>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/__tests__/__tests__.csproj
+++ b/__tests__/__tests__.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>__tests__</AssemblyName>
     <RootNamespace>__tests__</RootNamespace>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/lob.dotnet/Client/TolerantEnumConverter.cs
+++ b/src/lob.dotnet/Client/TolerantEnumConverter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Text.Json.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/src/lob.dotnet/Model/BankAccount.cs
+++ b/src/lob.dotnet/Model/BankAccount.cs
@@ -63,6 +63,33 @@ namespace lob.dotnet.Model
         [DataMember(Name = "account_type", IsRequired = true, EmitDefaultValue = false)]
         public AccountTypeEnum AccountType { get; set; }
         /// <summary>
+        /// Indicates which microdeposit verification path applies to this bank account. Null once verified.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum MicrodepositTypeEnum
+        {
+            /// <summary>
+            /// Enum Amounts for value: amounts
+            /// </summary>
+            [EnumMember(Value = "amounts")]
+            Amounts = 1,
+
+            /// <summary>
+            /// Enum DescriptorCode for value: descriptor_code
+            /// </summary>
+            [EnumMember(Value = "descriptor_code")]
+            DescriptorCode = 2
+
+        }
+
+        /// <summary>
+        /// Indicates which microdeposit verification path applies to this bank account. Null once verified.
+        /// </summary>
+        /// <value>Indicates which microdeposit verification path applies to this bank account. Null once verified.</value>
+        [DataMember(Name = "microdeposit_type", EmitDefaultValue = false)]
+        public MicrodepositTypeEnum? MicrodepositType { get; set; }
+
+        /// <summary>
         /// Defines Object
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
@@ -104,8 +131,9 @@ namespace lob.dotnet.Model
         /// <param name="dateCreated">A timestamp in ISO 8601 format of the date the resource was created. (required).</param>
         /// <param name="dateModified">A timestamp in ISO 8601 format of the date the resource was last modified. (required).</param>
         /// <param name="deleted">Only returned if the resource has been successfully deleted..</param>
+        /// <param name="microdepositType">Indicates which microdeposit verification path applies to this bank account. Null once verified.</param>
         /// <param name="_object">_object (required) (default to ObjectEnum.BankAccount).</param>
-        public BankAccount(string description = default(string), string routingNumber = default(string), string accountNumber = default(string), AccountTypeEnum accountType = default(AccountTypeEnum), string signatory = default(string), Dictionary<string, string> metadata = default(Dictionary<string, string>), string id = default(string), string signatureUrl = default(string), string bankName = default(string), bool verified = false, DateTime dateCreated = default(DateTime), DateTime dateModified = default(DateTime), bool deleted = default(bool), ObjectEnum _object = ObjectEnum.BankAccount)
+        public BankAccount(string description = default(string), string routingNumber = default(string), string accountNumber = default(string), AccountTypeEnum accountType = default(AccountTypeEnum), string signatory = default(string), Dictionary<string, string> metadata = default(Dictionary<string, string>), string id = default(string), string signatureUrl = default(string), string bankName = default(string), bool verified = false, DateTime dateCreated = default(DateTime), DateTime dateModified = default(DateTime), bool deleted = default(bool), MicrodepositTypeEnum? microdepositType = default(MicrodepositTypeEnum?), ObjectEnum _object = ObjectEnum.BankAccount)
         {
             // to ensure "routingNumber" is required (not null)
             if (routingNumber == null)
@@ -141,6 +169,7 @@ namespace lob.dotnet.Model
             this.BankName = bankName;
             this.Verified = verified;
             this.Deleted = deleted;
+            this.MicrodepositType = microdepositType;
         }
 
         /// <summary>
@@ -247,6 +276,7 @@ namespace lob.dotnet.Model
             sb.Append("  DateCreated: ").Append(DateCreated).Append("\n");
             sb.Append("  DateModified: ").Append(DateModified).Append("\n");
             sb.Append("  Deleted: ").Append(Deleted).Append("\n");
+            sb.Append("  MicrodepositType: ").Append(MicrodepositType).Append("\n");
             sb.Append("  Object: ").Append(Object).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -347,6 +377,10 @@ namespace lob.dotnet.Model
                     this.Deleted.Equals(input.Deleted)
                 ) && 
                 (
+                    this.MicrodepositType == input.MicrodepositType ||
+                    this.MicrodepositType.Equals(input.MicrodepositType)
+                ) &&
+                (
                     this.Object == input.Object ||
                     this.Object.Equals(input.Object)
                 );
@@ -404,6 +438,7 @@ namespace lob.dotnet.Model
                     hashCode = (hashCode * 59) + this.DateModified.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.Deleted.GetHashCode();
+                hashCode = (hashCode * 59) + this.MicrodepositType.GetHashCode();
                 hashCode = (hashCode * 59) + this.Object.GetHashCode();
                 return hashCode;
             }

--- a/src/lob.dotnet/Model/BankAccountVerify.cs
+++ b/src/lob.dotnet/Model/BankAccountVerify.cs
@@ -40,23 +40,27 @@ namespace lob.dotnet.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="BankAccountVerify" /> class.
         /// </summary>
-        /// <param name="amounts">In live mode, an array containing the two micro deposits (in cents) placed in the bank account. In test mode, no micro deposits will be placed, so any two integers between &#x60;1&#x60; and &#x60;100&#x60; will work. (required).</param>
-        public BankAccountVerify(List<int> amounts = default(List<int>))
+        /// <param name="amounts">In live mode, an array containing the two micro deposits (in cents) placed in the bank account. In test mode, no micro deposits will be placed, so any two integers between &#x60;1&#x60; and &#x60;100&#x60; will work.</param>
+        /// <param name="descriptorCode">The 6-character descriptor code that appears on the bank statement for accounts using the Stripe Financial Connections verification path. Exactly one of amounts or descriptor_code must be provided.</param>
+        public BankAccountVerify(List<int> amounts = default(List<int>), string descriptorCode = default(string))
         {
-            // to ensure "amounts" is required (not null)
-            if (amounts == null)
-            {
-                throw new ArgumentNullException("amounts is a required property for BankAccountVerify and cannot be null");
-            }
             this.Amounts = amounts;
+            this.DescriptorCode = descriptorCode;
         }
 
         /// <summary>
         /// In live mode, an array containing the two micro deposits (in cents) placed in the bank account. In test mode, no micro deposits will be placed, so any two integers between &#x60;1&#x60; and &#x60;100&#x60; will work.
         /// </summary>
         /// <value>In live mode, an array containing the two micro deposits (in cents) placed in the bank account. In test mode, no micro deposits will be placed, so any two integers between &#x60;1&#x60; and &#x60;100&#x60; will work.</value>
-        [DataMember(Name = "amounts", IsRequired = true, EmitDefaultValue = false)]
+        [DataMember(Name = "amounts", EmitDefaultValue = false)]
         public List<int> Amounts { get; set; }
+
+        /// <summary>
+        /// The 6-character descriptor code that appears on the bank statement for accounts using the Stripe Financial Connections verification path. Exactly one of amounts or descriptor_code must be provided.
+        /// </summary>
+        /// <value>The 6-character descriptor code that appears on the bank statement for accounts using the Stripe Financial Connections verification path.</value>
+        [DataMember(Name = "descriptor_code", EmitDefaultValue = false)]
+        public string DescriptorCode { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -67,6 +71,7 @@ namespace lob.dotnet.Model
             StringBuilder sb = new StringBuilder();
             sb.Append("class BankAccountVerify {\n");
             sb.Append("  Amounts: ").Append(Amounts).Append("\n");
+            sb.Append("  DescriptorCode: ").Append(DescriptorCode).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -101,12 +106,17 @@ namespace lob.dotnet.Model
             {
                 return false;
             }
-            return 
+            return
                 (
                     this.Amounts == input.Amounts ||
                     this.Amounts != null &&
                     input.Amounts != null &&
                     this.Amounts.SequenceEqual(input.Amounts)
+                ) &&
+                (
+                    this.DescriptorCode == input.DescriptorCode ||
+                    (this.DescriptorCode != null &&
+                    this.DescriptorCode.Equals(input.DescriptorCode))
                 );
         }
 
@@ -123,6 +133,10 @@ namespace lob.dotnet.Model
                 {
                     hashCode = (hashCode * 59) + this.Amounts.GetHashCode();
                 }
+                if (this.DescriptorCode != null)
+                {
+                    hashCode = (hashCode * 59) + this.DescriptorCode.GetHashCode();
+                }
                 return hashCode;
             }
         }
@@ -134,6 +148,28 @@ namespace lob.dotnet.Model
         /// <returns>Validation Result</returns>
         public IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(ValidationContext validationContext)
         {
+            bool hasAmounts = this.Amounts != null && this.Amounts.Count > 0;
+            bool hasDescriptorCode = !string.IsNullOrEmpty(this.DescriptorCode);
+
+            if (!hasAmounts && !hasDescriptorCode)
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Either amounts or descriptor_code must be provided.", new[] { "Amounts", "DescriptorCode" });
+            }
+
+            if (hasAmounts && hasDescriptorCode)
+            {
+                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Only one of amounts or descriptor_code may be provided, not both.", new[] { "Amounts", "DescriptorCode" });
+            }
+
+            if (hasDescriptorCode)
+            {
+                Regex regexDescriptorCode = new Regex(@"^[a-zA-Z0-9]{6}$", RegexOptions.CultureInvariant);
+                if (!regexDescriptorCode.Match(this.DescriptorCode).Success)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for DescriptorCode, must be a 6-character alphanumeric string.", new[] { "DescriptorCode" });
+                }
+            }
+
             yield break;
         }
     }

--- a/src/lob.dotnet/Model/CardUpdatable.cs
+++ b/src/lob.dotnet/Model/CardUpdatable.cs
@@ -38,7 +38,7 @@ namespace lob.dotnet.Model
         /// <param name="description">Description of the card..</param>
         /// <param name="autoReorder">Allows for auto reordering.</param>
         /// <param name="reorderQuantity">The quantity of items to be reordered (only required when auto_reorder is true)..</param>
-        public CardUpdatable(string description = default(string), bool autoReorder = default(bool), decimal reorderQuantity = default(decimal))
+        public CardUpdatable(string description = default(string), bool autoReorder = default(bool), decimal? reorderQuantity = default(decimal?))
         {
             this.Description = description;
             this.AutoReorder = autoReorder;
@@ -63,8 +63,8 @@ namespace lob.dotnet.Model
         /// The quantity of items to be reordered (only required when auto_reorder is true).
         /// </summary>
         /// <value>The quantity of items to be reordered (only required when auto_reorder is true).</value>
-        [DataMember(Name = "reorder_quantity", EmitDefaultValue = true)]
-        public decimal ReorderQuantity { get; set; }
+        [DataMember(Name = "reorder_quantity", EmitDefaultValue = false)]
+        public decimal? ReorderQuantity { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -123,7 +123,8 @@ namespace lob.dotnet.Model
                 ) && 
                 (
                     this.ReorderQuantity == input.ReorderQuantity ||
-                    this.ReorderQuantity.Equals(input.ReorderQuantity)
+                    (this.ReorderQuantity != null &&
+                    this.ReorderQuantity.Equals(input.ReorderQuantity))
                 );
         }
 
@@ -141,7 +142,10 @@ namespace lob.dotnet.Model
                     hashCode = (hashCode * 59) + this.Description.GetHashCode();
                 }
                 hashCode = (hashCode * 59) + this.AutoReorder.GetHashCode();
-                hashCode = (hashCode * 59) + this.ReorderQuantity.GetHashCode();
+                if (this.ReorderQuantity != null)
+                {
+                    hashCode = (hashCode * 59) + this.ReorderQuantity.GetHashCode();
+                }
                 return hashCode;
             }
         }
@@ -159,16 +163,17 @@ namespace lob.dotnet.Model
                 yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for Description, length must be less than 255.", new [] { "Description" });
             }
 
-            // ReorderQuantity (decimal) maximum
-            if (this.ReorderQuantity > (decimal)10000000)
+            if (this.ReorderQuantity != null)
             {
-                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ReorderQuantity, must be a value less than or equal to 10000000.", new [] { "ReorderQuantity" });
-            }
+                if (this.ReorderQuantity > (decimal)10000000)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ReorderQuantity, must be a value less than or equal to 10000000.", new [] { "ReorderQuantity" });
+                }
 
-            // ReorderQuantity (decimal) minimum
-            if (this.ReorderQuantity < (decimal)10000)
-            {
-                yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ReorderQuantity, must be a value greater than or equal to 10000.", new [] { "ReorderQuantity" });
+                if (this.ReorderQuantity < (decimal)10000)
+                {
+                    yield return new System.ComponentModel.DataAnnotations.ValidationResult("Invalid value for ReorderQuantity, must be a value greater than or equal to 10000.", new [] { "ReorderQuantity" });
+                }
             }
 
             yield break;

--- a/src/lob.dotnet/lob.dotnet.csproj
+++ b/src/lob.dotnet/lob.dotnet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo><!-- setting GenerateAssemblyInfo to false causes this bug https://github.com/dotnet/project-system/issues/3934 -->
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>lob.dotnet</AssemblyName>
     <PackageId>lob.dotnet</PackageId>
     <OutputType>Library</OutputType>

--- a/src/lob.dotnet/lob.dotnet.csproj
+++ b/src/lob.dotnet/lob.dotnet.csproj
@@ -11,7 +11,7 @@
     <AssemblyTitle>OpenAPI Library</AssemblyTitle>
     <Description>A library generated from a OpenAPI spec for the Csharp language</Description>
     <RootNamespace>lob.dotnet</RootNamespace>
-    <Version>1.1.3</Version>
+    <Version>1.2.0</Version>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\lob.dotnet.xml</DocumentationFile>
     <RepositoryUrl>https://github.com/lob/lob-dotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## Description

**Problem:** Stripe updated their bank account microdeposit verification from two deposit amounts to a single descriptor code (a 6-character alphanumeric string beginning with `SM` that appears on the customer's bank statement). The dotnet SDK had no support for this path, so customers whose accounts were assigned `microdeposit_type: descriptor_code` could not complete verification through the SDK.

**Solution:** Added `descriptor_code` as an alternative to `amounts` on `BankAccountVerify`, updated validation so exactly one of the two fields is required (not both, not neither), and added `microdeposit_type` to the `BankAccount` response model so callers can read which verification path applies to a given account before calling verify.

Also migrates the library target from `netcoreapp3.1` to `netstandard2.0` (correct for a redistributable SDK — compatible with .NET Framework 4.6.1+, .NET Core 2.0+, and all modern .NET) and the test project from `netcoreapp3.1` to `net10.0` (current LTS, available via mise).

**Non-breaking:** All existing code using `amounts` continues to work without any changes.

## Story

https://lobsters.atlassian.net/browse/BILL-5589 (subtask of https://lobsters.atlassian.net/browse/BILL-5581)

## Related PRs

- lob-php reference implementation: https://github.com/lob/lob-php/pull/192

## Verify

- [x] Code runs without errors
- [x] 183 unit tests pass (`dotnet test --filter "Category=Unit"`)